### PR TITLE
enhancement: secrets unset-all

### DIFF
--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -42,6 +42,7 @@ func New() *cobra.Command {
 		newList(),
 		newSet(),
 		newUnset(),
+		newUnsetAll(),
 		newImport(),
 		newDeploy(),
 		newKeys(),

--- a/internal/command/secrets/unset_all.go
+++ b/internal/command/secrets/unset_all.go
@@ -1,0 +1,50 @@
+package secrets
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
+)
+
+func newUnsetAll() (cmd *cobra.Command) {
+	const (
+		long  = `Unset all encrypted secrets for an application`
+		short = long
+		usage = "unset-all"
+	)
+
+	cmd = command.New(usage, short, long, runUnsetAll, command.RequireSession, command.RequireAppName)
+
+	flag.Add(cmd,
+		sharedFlags,
+	)
+
+	return cmd
+}
+
+func runUnsetAll(ctx context.Context) (err error) {
+	client := flyutil.ClientFromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
+	app, err := client.GetAppCompact(ctx, appName)
+
+	if err != nil {
+		return err
+	}
+
+	appSecrets, err := client.GetAppSecrets(ctx, appName)
+
+	if err != nil {
+		return err
+	}
+
+	var secrets []string
+	for _, secret := range appSecrets {
+		secrets = append(secrets, secret.Name)
+	}
+
+	return UnsetSecretsAndDeploy(ctx, app, secrets, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+}


### PR DESCRIPTION
- desc: add runUnsetAll to secrets.New(); runUnsetAll uses client.GetAppSecrets, otherwise its the same code as runUnset

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
